### PR TITLE
Updates termination wait time to 60 minutes. Fix duplicate trigger.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Available targets:
 | alb_ssl_listener_arn | ALB SSL listener arn  for Blue/Green | string | `` | no |
 | alb_test_listener_arn | ALB test listener arn  for Blue/Green | string | `` | no |
 | alb_ingress_prod_listener_arns_count | The number of production ingress listeners | string | `0` | no |
+| blue_termination_wait_time_in_minutes | The number of minutes to wait after a successful deployment before terminating the old instances. | string | `60` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -110,6 +110,7 @@
 | alb_ssl_listener_arn | ALB SSL listener arn  for Blue/Green | string | `` | no |
 | alb_test_listener_arn | ALB test listener arn  for Blue/Green | string | `` | no |
 | alb_ingress_prod_listener_arns_count | The number of production ingress listeners | string | `0` | no |
+| blue_termination_wait_time_in_minutes | The number of minutes to wait after a successful deployment before terminating the old instances. | string | `60` | no |
 
 ## Outputs
 
@@ -124,4 +125,3 @@
 | task_role_name | ECS Task role name |
 | webhook_id | The CodePipeline webhook's ARN. |
 | webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target. |
-

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_codedeploy_deployment_group" "default" {
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = 5
+      termination_wait_time_in_minutes = "${var.blue_termination_wait_time_in_minutes}"
     }
   }
 
@@ -188,7 +188,7 @@ resource "aws_codedeploy_deployment_group" "with_ssl" {
   service_role_arn       = "${module.ecs_bg_codepipeline.default_role_arn}"
 
   trigger_configuration {
-    trigger_events     = ["DeploymentSuccess", "DeploymentFailure", "DeploymentReady", "DeploymentFailure"]
+    trigger_events     = ["DeploymentSuccess", "DeploymentFailure", "DeploymentReady", "DeploymentRollback"]
     trigger_name       = "Update SSL Rule"
     trigger_target_arn = "${module.update_ssl_rule.this_sns_topic_arn}"
   }
@@ -205,7 +205,7 @@ resource "aws_codedeploy_deployment_group" "with_ssl" {
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = 5
+      termination_wait_time_in_minutes = "${var.blue_termination_wait_time_in_minutes}"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -641,3 +641,9 @@ variable "alb_ingress_prod_listener_arns_count" {
   default     = "0"
   description = "The number of production ingress listeners for Blue Green, usually http/s"
 }
+
+variable "blue_termination_wait_time_in_minutes" {
+  type        = "string"
+  default     = "60"
+  description = "The number of minutes to wait after a successful deployment before terminating the old instances."
+}


### PR DESCRIPTION
- Add default old deployment termination wait og 1 hour.
- Fixes duplicate trigger event