### PR TITLE
Some actions may not be ForwardConfig.

### DIFF
--- a/sns_lambda_update_ssl_rule/functions/update_ssl_rule.py
+++ b/sns_lambda_update_ssl_rule/functions/update_ssl_rule.py
@@ -69,12 +69,14 @@ def get_current_http_target_group(http_listener_rules, arr_available_target_grou
 
         actions = http_listener_rules[i]['Actions']
         n=0
+
         while n<len(actions):
-
-            for tg in actions[n]['ForwardConfig']['TargetGroups']:
-                if tg['TargetGroupArn'] in arr_available_target_groups and tg['Weight'] is 100:
-                    return tg['TargetGroupArn']
-
+            try:
+                for tg in actions[n]['ForwardConfig']['TargetGroups']:
+                    if tg['TargetGroupArn'] in arr_available_target_groups and (tg['Weight'] is 100 or tg['Weight'] is 1) :
+                        return tg['TargetGroupArn']
+            except Exception as e:
+                print(e)
             n +=1
 
         i +=1


### PR DESCRIPTION
Add exception handler for missing key.

This was manually deployed in dev and should be included as part of the terraform module.